### PR TITLE
Add a maxlength plugin

### DIFF
--- a/src/plugins/maxlength/main.rs
+++ b/src/plugins/maxlength/main.rs
@@ -1,0 +1,52 @@
+use overrider::*;
+
+use crate::config::ConfigDefault;
+use crate::drw::Drw;
+use crate::item::Item;
+use crate::result::*;
+use crate::clapflags::CLAP_FLAGS;
+
+use unicode_segmentation::UnicodeSegmentation;
+
+#[override_flag(flag = maxlength)]
+impl Drw {
+    pub fn postprocess_matches(&mut self, current_matches: Vec<Item>) -> CompResult<Vec<Item>> {
+	let max_length_str_option = CLAP_FLAGS.value_of( "maxlength" );
+
+	match max_length_str_option
+	{
+		None => {
+			Err(Die::Stderr("Please specificy max length".to_owned()))
+		},
+		Some( max_length_str ) => 
+		{
+			let max_length_result = max_length_str.parse::<usize>();
+			match max_length_result
+			{
+				Err( _ ) => Err(Die::Stderr("Please specificy a positive integer for max length".to_owned())),
+				Ok( 0 ) => Ok( current_matches ),
+				Ok( max_length ) => {
+					// >= in place of = in case someoen pastes stuff in
+					// when there is a paste functionality.
+					if self.input.graphemes(true).count() >= max_length
+					{
+						self.dispose( self.input.graphemes(true).take( max_length ).collect(), true )?;
+						Err(Die::Stdout("".to_owned()))
+					}
+					else
+					{
+						Ok(current_matches)
+					}
+				}
+			}
+		}
+	}
+	}
+}
+
+#[override_flag(flag = maxlength)]
+impl ConfigDefault {
+    pub fn nostdin() -> bool {
+	true
+    }
+}

--- a/src/plugins/maxlength/plugin.yml
+++ b/src/plugins/maxlength/plugin.yml
@@ -1,0 +1,14 @@
+about: |
+  Specify a maximum length of input, 
+  usually used without menu items. 
+  Acts as a replacement for `i3-input -l`
+  Pass --maxlength=<MAXLENGTH> to use
+entry: main.rs 
+
+args:
+  - maxlength:
+      help: Limit maximum length of input
+      long: maxlength
+      takes_value: true
+      value_name: MAXLENGTH
+      # short: 


### PR DESCRIPTION
A replacement for i3-input -l

Hi, I'm not sure how well this fits with your philosophy so please feel free to reject. 

What this adds- a flag `maxlength` which lets you specify the maximum length of input string after which the prompt returns with the input string, without having to press enter. It's a replacement for `i3-input -l`. I should note that there is a bit of difference between your more performant reimplementation and the original dmenu. Difference:


* Original
`echo ''| dmenu` , followed by input and `enter` outputs the input text. Thus being usable as a replacement for `i3-input` 

* Your implementation
`echo ''| dmenu` , followed by input and `enter` outputs blank. 

This plugin outputs the input (but only when a maxlength is supplied). 

Example usage: `echo ''| dmenu --maxlength=5` followed by an input, auto-terminates upon length being exceeded. 

### Testing: 

* Tested with no input to maxlength
* Tested with a string input to maxlength- "xy"
* Tested with "0" input to maxlength (Retains original behavior of outputing blank)
* Tested with input `5`.

### Code

* The main logic is on line 30-31 which I copied from your autoselect improvement.
* Parentheses and nesting, I see you probably prefer not indenting code inside a function, so I've tried to do so. 

Let me know if you want me to make improvements. 
