### PR TITLE
fix typo: PATCH -> PLUGINS

### DIFF
--- a/src/config/src/list_plugins.rs
+++ b/src/config/src/list_plugins.rs
@@ -66,7 +66,7 @@ fn main() {
 
     let mut table_footer = Table::new();
     table_footer.add_row(Row::new(vec![
-	Cell::new("To enable plugins, read the PATCH section in config.mk")
+	Cell::new("To enable plugins, read the PLUGINS section in config.mk")
 	    .with_style(Attr::Bold)
 	    .with_style(Attr::ForegroundColor(color::BLUE))
     ]));


### PR DESCRIPTION
Hello!

I think this fixes a minor typo. I didn't find any mention of `PATCH` anywhere in the repository besides the message returned by `make; make plugins`.