### PR TITLE
use default c compiler instead of hardcoded clang

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -11,7 +11,7 @@ XINERAMA=true
 CFLAGS = -c -pedantic -std=c99 -Wall -Os -D_DEFAULT_SOURCE
 
 # compiler and linker for non-rust files, blank for system default (cc)
-CC = clang
+CC =
 
 # additional flags to be passed to rustc
 RUSTFLAGS =


### PR DESCRIPTION
While adding dmenu-rs as a package to my distro, some reviewers suggested the hardcoded clang be dropped upstream in favor of using the system default.

See: https://github.com/NixOS/nixpkgs/pull/200977