### PR TITLE
fix broken make install

### DIFF
--- a/makefile
+++ b/makefile
@@ -53,6 +53,7 @@ plugins:
 stest:
 	cd src && cargo build -p stest --release $(XINERAMA_FLAGS)
 	cp src/target/release/stest target/
+	cp src/man/src/stest.1 target/
 
 scaffold:
 	mkdir -p target


### PR DESCRIPTION
I broke make install in an earlier commit :'( (sorry)

Specifically, the following line in make install does not work

	sed "s/VERSION/$(VERSION)/g" < target/stest.1 > $(DESTDIR)$(MANPREFIX)/man1/stest.1

This fixes it. I'd forgotten to keep the man page copy into target step
when rewriting stest in Rust.