### PR TITLE
fix: stest: filename instead of file path

### DIFF
--- a/src/stest/src/file.rs
+++ b/src/stest/src/file.rs
@@ -208,7 +208,7 @@ impl File {
 
 impl Display for File {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FmtError> {
-        let display = self.path_buf.display();
+        let display = self.path_buf.file_name().unwrap().to_str().unwrap();
         write!(f, "{display}")
     }
 }


### PR DESCRIPTION
I'm using the `dmenu_run` script (via `dwm`), and found that the commands in the dmenu were showing up as full path instead of just file names. I've made the stest output similar to the original stest as it was more convenient for me to see just the file names up there.  
Feel free to reject the PR if this is not desired behaviour for this project.
I'm unaware of the edge cases and hence used `unwrap` here, since it hasn't failed for me i'm assuming it should be fine (guess i'll do the error handling when something actually breaks :P).