### PR TITLE
fix: stest: file name while writing with l option

### DIFF
--- a/src/stest/src/file.rs
+++ b/src/stest/src/file.rs
@@ -36,9 +36,7 @@ impl File {
 
     pub fn read_directory(&self) -> Result<Vec<File>, std::io::Error> {
         fn dir_entry_to_file(dir_entry: DirEntry) -> File {
-            let file_name = dir_entry.file_name();
-            let path_buf = PathBuf::from(file_name.to_string_lossy().to_string());
-            File::new(path_buf)
+            File::new(dir_entry.path())
         }
         let iterator = read_dir(&self.path_buf)?;
         iterator
@@ -173,6 +171,13 @@ impl File {
             mode & 0o111 != 0
         }
         self.mode().map(is_executable)
+    }
+
+    pub fn file_name(&self) -> String {
+        self.path_buf
+            .file_name()
+            .and_then(|f| Some(f.to_string_lossy().to_string()))
+            .unwrap_or_else(|| "".to_string())
     }
 
     fn metadata(&self) -> Result<Metadata, io::Error> {

--- a/src/stest/src/file.rs
+++ b/src/stest/src/file.rs
@@ -173,11 +173,11 @@ impl File {
         self.mode().map(is_executable)
     }
 
-    pub fn file_name(&self) -> String {
+    pub fn clone_with_path_as_file_name(&self) -> Option<File> {
         self.path_buf
             .file_name()
-            .map(|f| f.to_string_lossy().to_string())
-            .unwrap_or_else(|| "".to_string())
+            .map(|os_str| PathBuf::from(os_str))
+            .map(|path_buf| File::new(path_buf))
     }
 
     fn metadata(&self) -> Result<Metadata, io::Error> {

--- a/src/stest/src/file.rs
+++ b/src/stest/src/file.rs
@@ -176,7 +176,7 @@ impl File {
     pub fn file_name(&self) -> String {
         self.path_buf
             .file_name()
-            .and_then(|f| Some(f.to_string_lossy().to_string()))
+            .map(|f| f.to_string_lossy().to_string())
             .unwrap_or_else(|| "".to_string())
     }
 

--- a/src/stest/src/lib.rs
+++ b/src/stest/src/lib.rs
@@ -157,7 +157,9 @@ impl App {
             ()
         } else {
             let mut string = if self.config.test_contents_of_directories {
-                file.file_name()
+                file.clone_with_path_as_file_name()
+                    .map(|f| f.to_string())
+                    .expect("contents of the directory won't include '..'")
             } else {
                 file.to_string()
             };

--- a/src/stest/src/lib.rs
+++ b/src/stest/src/lib.rs
@@ -156,7 +156,11 @@ impl App {
         if self.config.quiet {
             ()
         } else {
-            let mut string = file.to_string();
+            let mut string = if self.config.test_contents_of_directories {
+                file.file_name()
+            } else {
+                file.to_string()
+            };
             string.push('\n');
             let bytes = string.as_bytes();
             stdout.write_all(bytes)?

--- a/src/stest/tests/integration_tests.rs
+++ b/src/stest/tests/integration_tests.rs
@@ -114,6 +114,7 @@ fn test_contents_of_directories() -> () {
                 .into_iter()
                 .map(|file| file.read_directory().unwrap())
                 .flatten()
+                .map(|f| f.clone_with_path_as_file_name().unwrap())
                 .collect()
         };
         (directory, contents)


### PR DESCRIPTION
The PR #54 was not the correct fix for #53  - since the file paths are being passed for further processing.  
This PR fixes that and uses file names only while printing only if the `-l` option is used.