### PR TITLE
fix: dmenu_path: create cache if it doesnt exist

### DIFF
--- a/src/sh/dmenu_path
+++ b/src/sh/dmenu_path
@@ -6,7 +6,7 @@ cache="$cachedir/dmenu_run"
 [ ! -e "$cachedir" ] && mkdir -p "$cachedir"
 
 IFS=:
-if stest -dqr -n "$cache" $PATH; then
+if [ ! -f "$cache" ] || stest -dqr -n "$cache" $PATH; then
 	stest -flx $PATH | sort -u | tee "$cache"
 else
 	cat "$cache"


### PR DESCRIPTION
This PR deviates from the behaviour of the original dmenu_path script so I'm unsure if it would be acceptable in this repo.

Deleting the `dmenu_run` cache and running `dmenu_path` is not regenerating the cache in the original dmenu either for me - for both original and dmenu-rs, i get the error that the file doesn't exist.
```
$ ./stest -flx -n ~/.cache/dmenu_run .
/home/light/.cache/dmenu_run: No such file or directory
dmenu
dmenu_run
dmenu_path
stest
```
The arch linux wiki says that it should regenerate it when deleted (https://wiki.archlinux.org/title/dmenu#Missing_menu_entries) , but on my system that didn't happen and I was unable to find any code path that regenerates the cache, so here I'm assuming that this problem is not just on my system - please correct me if I'm wrong.

This PR adds a condition that if the cache doesn't exist, then we add the cache before checking for last modified date of the file with stest.