### PR TITLE
stest: fix bugs that deviate from original stest

### DIFF
--- a/src/stest/src/config.rs
+++ b/src/stest/src/config.rs
@@ -22,6 +22,18 @@ pub struct Config {
     #[arg(short = 'd')]
     pub requires_each_file_is_directory: bool,
     /// Test that files exist.
+    ///
+    /// This option does not actually alter the behavior of stest. By default, stest will always
+    /// test that a file exists.
+    ///
+    /// This behavior deviates from the behavior of the POSIX test utility, which requires the -e
+    /// option in order to perform an existence test on a file. This deviation, together with the
+    /// fact that it's counterintuitive to provide an option that has no effect, implies that this
+    /// may be a bug in the C implementation of stest in the original dmenu repository. The
+    /// behavior is reproduced here because this rust implementation strives to be a drop-in
+    /// replacement for the original and because it's unlikely that this behavior could
+    /// meaningfully impact the experience of using dmenu_run: non-existing files on your PATH
+    /// cannot be executed successfully, so it's always reasonable to filter them out.
     #[arg(short = 'e')]
     pub requires_each_file_exists: bool,
     /// Test that files are regular files.
@@ -40,9 +52,22 @@ pub struct Config {
     #[arg(short = 'l')]
     pub test_contents_of_directories: bool,
     /// Test that files are newer (by modification time) than file.
+    ///
+    /// If this option is given a non-existing file as its argument, the test is ignored.
+    ///
+    /// This behavior is similar to assuming the last modification time of a non-existent file is a
+    /// lower bound like the unix epoch or zero, and is consistent with the behavior of GNU
+    /// coreutils' test.
     #[arg(short = 'n')]
     pub oldest_file: Option<File>,
     /// Test that files are older (by modification time) than file.
+    ///
+    /// If this option is given a non-existing file as its argument, the test is ignored.
+    ///
+    /// This behavior is similar to assuming the last modification time of a non-existent file is
+    /// an upper bound like infinity. Note that this behavior is not consistent with the behavior
+    /// of GNU coreutils' test: checking that a file is older than (-ot) a non-existent file with
+    /// GNU coreutils' test always fails, while checking the same with stest (-o) always passes.
     #[arg(short = 'o')]
     pub newest_file: Option<File>,
     /// Test that files are named pipes.

--- a/src/stest/src/config.rs
+++ b/src/stest/src/config.rs
@@ -48,7 +48,7 @@ pub struct Config {
     /// Test that files are named pipes.
     #[arg(short = 'p')]
     pub requires_each_file_is_pipe: bool,
-    /// No files are printed, only the exist status is returned.
+    /// No files are printed, only the exit status is returned.
     #[arg(short = 'q')]
     pub quiet: bool,
     /// Test that files are readable.

--- a/src/stest/src/file.rs
+++ b/src/stest/src/file.rs
@@ -2,9 +2,9 @@ use clap::Parser;
 use std::clone::Clone;
 use std::fmt::Error as FmtError;
 use std::fmt::{Display, Formatter};
+use std::fs::read_dir;
 use std::fs::DirEntry;
 use std::fs::Metadata;
-use std::fs::read_dir;
 use std::io;
 use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::path::Component;
@@ -119,7 +119,7 @@ impl File {
         match file.last_modified_without_default() {
             Ok(newest_modified_time) => Ok(modified_time < newest_modified_time),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(true),
-            Err(error) => Err(error)
+            Err(error) => Err(error),
         }
     }
 
@@ -195,7 +195,7 @@ impl File {
         match result {
             Ok(system_time) => Ok(system_time),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(SystemTime::UNIX_EPOCH),
-            Err(error) => Err(error)
+            Err(error) => Err(error),
         }
     }
 
@@ -214,7 +214,6 @@ impl File {
         }
         self.metadata().map(metadata_to_mode)
     }
-
 }
 
 impl Display for File {

--- a/src/stest/src/lib.rs
+++ b/src/stest/src/lib.rs
@@ -117,7 +117,7 @@ impl App {
             && (!self.config.requires_each_file_is_character_special
                 || file.is_character_special()?)
             && (!self.config.requires_each_file_is_directory || file.is_directory())
-            && (!self.config.requires_each_file_exists || file.exists()?)
+            && file.exists()? // See comments on the requires_each_file_exists option in config.rs.
             && (!self.config.requires_each_file_is_file || file.is_file())
             && (!self.config.requires_each_file_has_set_group_id || file.has_set_group_id()?)
             && (!self.config.requires_each_file_is_symbolic_link || file.is_symbolic_link())

--- a/src/stest/src/lib.rs
+++ b/src/stest/src/lib.rs
@@ -101,7 +101,11 @@ impl App {
     /// Test that a file passes all configured tests.
     ///
     /// Each test is optional. If a test is disabled, the result is true by default. Only if it's
-    /// enabled do we test the given file. This is expressed with the following boolean logic
+    /// enabled do we test the given file. A natural expression of this in boolean logic is
+    ///
+    ///   !config.is_test_enabled || (config.is_test_enabled && test)
+    ///
+    /// This simplifies to the following shorter expression that we use for each test.
     ///
     ///   !config.is_test_enabled || test
     ///

--- a/src/stest/tests/integration_tests.rs
+++ b/src/stest/tests/integration_tests.rs
@@ -252,7 +252,7 @@ fn test_older_than_newest_file() -> () {
 /// Test stest configured with the older than option (-o) that is passed a file that does not
 /// exist.
 ///
-/// This test expects stest to ignore the newer than check when passed a file that does not exist.
+/// This test expects stest to ignore the older than check when passed a file that does not exist.
 /// See comments on this option in config.rs for more details.
 #[test]
 fn test_older_than_newest_file_that_does_not_exist() -> () {


### PR DESCRIPTION
This fixes a couple bugs in stest where its behavior deviated from the original C implementation.

There's more detail than anyone probably cares to read in one of the [commit messages][1]. Shorter commentary on the issues can be found in stest's `config.rs`.

This is also related to the issue raised in [#56][2].

These changes were verified by additional tests in the `integration_tests.rs` file. I also built the changes and tested `dmenu_run` on my local system with a missing `~/.cache/dmenu_run` file. The cache file was recreated as expected.

[1]: https://github.com/benjaminedwardwebb/dmenu-rs/commit/3e4fd34b70e9416ed40963dab74035807b61ea16
[2]: https://github.com/Shizcow/dmenu-rs/pull/56